### PR TITLE
Limits TOC to h2 only and other menu improvements

### DIFF
--- a/src/Nacara.Layout.Standard/Source/Page.WithMenuOrToc.fs
+++ b/src/Nacara.Layout.Standard/Source/Page.WithMenuOrToc.fs
@@ -3,35 +3,8 @@ module Page.WithMenuOrToc
 open Nacara.Core.Types
 open Feliz
 open Feliz.Bulma
-open Fable.FontAwesome
 
-let private renderTopLevelToc (section : TableOfContentParser.Section) =
-    Html.li [
-        Html.a [
-            prop.dangerouslySetInnerHTML section.Header.Title
-            prop.href section.Header.Link
-            prop.custom("data-toc-element", true)
-        ]
-
-        if not section.SubSections.IsEmpty then
-
-            Html.ul [
-                prop.className "table-of-content"
-
-                prop.children [
-                    for subSection in section.SubSections do
-                        Html.li [
-                            Html.a [
-                                prop.dangerouslySetInnerHTML subSection.Title
-                                prop.href subSection.Link
-                                prop.custom("data-toc-element", true)
-                            ]
-                        ]
-                ]
-            ]
-    ]
-
-let private renderTableOfContents (tableOfContent : TableOfContentParser.Section list) =
+let private renderTableOfContents (tableOfContent : TableOfContentParser.Header list) =
     if tableOfContent.Length > 0 then
         Html.li [
             Html.ul [
@@ -39,7 +12,13 @@ let private renderTableOfContents (tableOfContent : TableOfContentParser.Section
 
                 prop.children [
                     for tocElement in tableOfContent do
-                        renderTopLevelToc tocElement
+                        Html.li [
+                            Html.a [
+                                prop.dangerouslySetInnerHTML tocElement.Title
+                                prop.href tocElement.Link
+                                prop.custom("data-toc-element", true)
+                            ]
+                        ]
                 ]
             ]
         ]
@@ -51,7 +30,7 @@ let private renderMenuItemPage
     (pages : PageContext array)
     (info : MenuItemPage)
     (currentPageId : string)
-    (tocInformation : TableOfContentParser.Section list) =
+    (tocInformation : TableOfContentParser.Header list) =
 
     let labelText =
         match info.Label with
@@ -81,9 +60,6 @@ let private renderMenuItemPage
     let isCurrentPage =
         info.PageId = currentPageId
 
-    let hasTableOfContent =
-        not tocInformation.IsEmpty
-
     React.fragment [
         Bulma.menuItem.a [
             prop.classes [
@@ -107,7 +83,7 @@ let rec private renderSubMenu
     (pages : PageContext array)
     (menu : Menu)
     (currentPageId : string)
-    (tocInformation : TableOfContentParser.Section list) =
+    (tocInformation : TableOfContentParser.Header list) =
 
     menu
     |> List.map (
@@ -116,42 +92,13 @@ let rec private renderSubMenu
             Bulma.menuItem.a [
                 prop.href info.Href
                 prop.text info.Label
+                prop.target.blank
             ]
 
         | MenuItem.Page info ->
             renderMenuItemPage config pages info currentPageId tocInformation
 
-        | MenuItem.List info ->
-            let defaultState =
-                if info.Collapsed then
-                    "collapsed"
-                else
-                    "expanded"
-            Html.li [
-                Html.a [
-                    prop.classes [
-                        "menu-group"
-                        if not info.Collapsed then
-                            "is-expanded"
-                    ]
-                    prop.custom("data-default-state", defaultState)
-                    prop.custom("data-collapsible", info.Collapsible)
-                    prop.children [
-                        Html.span info.Label
-
-                        if info.Collapsible then
-                            Bulma.icon [
-                                Fa.i [ Fa.Solid.AngleRight; Fa.Size Fa.FaLarge ]
-                                    [  ]
-                            ]
-                    ]
-                ]
-
-                Html.ul [
-                    yield! renderSubMenu config pages info.Items currentPageId tocInformation
-                ]
-            ]
-
+        | _ -> Html.none
     )
 
 /// <summary>
@@ -162,20 +109,27 @@ let rec private renderMenu
     (pages : PageContext array)
     (menu : Menu)
     (currentPageId : string)
-    (tocInformation : TableOfContentParser.Section list) =
+    (tocInformation : TableOfContentParser.Header list) =
 
     let menuContent =
         menu
         |> List.map (
             function
             | MenuItem.Link info ->
-                Bulma.menuItem.a [
-                    prop.href info.Href
-                    prop.text info.Label
+                Bulma.menuList [
+                    Bulma.menuItem.a [
+                        prop.href info.Href
+                        prop.text info.Label
+                        prop.target.blank
+                    ]
                 ]
 
             | MenuItem.Page info ->
-                renderMenuItemPage config pages info currentPageId tocInformation
+                Bulma.menuList [
+                    Html.li [
+                        renderMenuItemPage config pages info currentPageId tocInformation
+                    ]
+                ]
 
             | MenuItem.List info ->
                 React.fragment [
@@ -254,7 +208,7 @@ let private renderPageWithoutMenuOrTableOfContent (pageContent : ReactElement) =
     ]
 
 let private renderTableOfContentOnly
-    (tocInformation : TableOfContentParser.Section list) =
+    (tocInformation : TableOfContentParser.Header list) =
 
     Html.div [
         prop.className "menu-container"
@@ -370,7 +324,7 @@ type RenderArgs =
 let render (args : RenderArgs) =
 
     let tocInformation =
-        TableOfContentParser.parse args.PageHtml args.PageContext.RelativePath
+        TableOfContentParser.parse args.PageHtml
 
     if args.RenderMenu then
         match args.SectionMenu, tocInformation.IsEmpty with
@@ -408,3 +362,4 @@ let render (args : RenderArgs) =
                 null // No breadcrumb because there is no menu
                 (renderTableOfContentOnly tocInformation)
                 args.PageContent
+

--- a/src/Nacara.Layout.Standard/Source/Page.WithMenuOrToc.fs
+++ b/src/Nacara.Layout.Standard/Source/Page.WithMenuOrToc.fs
@@ -90,6 +90,7 @@ let rec private renderSubMenu
         function
         | MenuItem.Link info ->
             Bulma.menuItem.a [
+                prop.className "menu-external-link"
                 prop.href info.Href
                 prop.text info.Label
                 prop.target.blank
@@ -362,4 +363,3 @@ let render (args : RenderArgs) =
                 null // No breadcrumb because there is no menu
                 (renderTableOfContentOnly tocInformation)
                 args.PageContent
-

--- a/src/Nacara.Layout.Standard/Source/TableOfContentParser.fs
+++ b/src/Nacara.Layout.Standard/Source/TableOfContentParser.fs
@@ -4,112 +4,24 @@ module TableOfContentParser
 open System.Text.RegularExpressions
 
 type Header =
-    {
-        Title : string
-        Link : string
-    }
+    { Title : string
+      Link : string }
 
-// Represents an Header2
-type Section =
-    {
-        Header : Header
-        SubSections : Header list
-    }
+type TableOfContent = Header list
 
-type TableOfContent = Section list
-
-
-let private (|Match|_|) pattern input =
-    let m = Regex.Match(input, pattern, RegexOptions.Singleline)
-    if m.Success then
-        Some m
-    else
-        None
-
-let private isNotNull (o : 'T) =
-   not (isNull o)
-
-let private (|Header2|_|) (m : Match) : option<Header> =
-    if isNotNull m.Groups.[1] then
-        {
-            Title = m.Groups.["h2_text"].Value
-            Link = m.Groups.["h2_link"].Value
-        }
-        |> Some
-    else
-        None
-
-let private (|Header3|_|) (m : Match) : option<Header> =
-    if isNotNull m.Groups.[6] then
-        {
-            Title = m.Groups.["h3_text"].Value
-            Link = m.Groups.["h3_link"].Value
-        }
-        |> Some
-    else
-        None
-
-let rec private extractSection (filePath : string) (acc : Section option) (res : TableOfContent) (matches : Match list) =
-    match matches with
-    | head :: tail ->
-        match head with
-        | Header2 header ->
-            // If we find an header2 and another header2 is already in process
-            // Close put the current header2 into the result and start tracking the new header2
-            match acc with
-            | Some section ->
-                let newSection : Section =
-                    {
-                        Header = header
-                        SubSections = []
-                    }
-
-                extractSection filePath (Some newSection) (res @ [section]) tail
-
-            // If this is the first header2 start tracking it
-            | None ->
-                let newSection : Section =
-                    {
-                        Header = header
-                        SubSections = []
-                    }
-
-                extractSection filePath (Some newSection) res tail
-
-        | Header3 header ->
-            match acc with
-            // If an header3 is found inside an header2, add it to the SubSections
-            | Some section ->
-                let section =
-                    { section with
-                        SubSections = section.SubSections @ [ header ]
-                    }
-
-                extractSection filePath (Some section) res tail
-
-            // If an header3 is found outside of an header2, print an error as this should not be the case
-            | None ->
-                failwithf "Error in the file: %s\nAn h3 element should be the child of an h2 element" filePath
-
-        // Not a h2 or h3 continue the parsing
-        | _ ->
-            extractSection filePath acc res tail
-
-    // No more line to handle
-    | [ ] ->
-        // Close the current section if there is one and return the result
-        match acc with
-        | Some section ->
-            res @ [section]
-
-        | None ->
-            res
-
-// Note: TableOfContent parser only extract information from h2 and h3 elements
-let parse (pageContent : string) (filePath : string) =
-    let pattern = """(<h2[^>]*>(?<h2_text>((?!<\/h2>).)*)<a\s*href="(?<h2_link>[^"]*)"((?!<\/h2>).)*<\/h2>)|(<h3[^>]*>(?<h3_text>((?!<\/h3>).)*)<a\s*href="(?<h3_link>[^"]*)"((?!<\/h3>).)*<\/h3>)"""
+// Note: TableOfContent parser only extract information from h2 elements
+let parse (pageContent : string) =
+    let pattern = """(<h2[^>]*>(?<h2_text>((?!<\/h2>).)*)<a\s*href="(?<h2_link>[^"]*)"((?!<\/h2>).)*<\/h2>)"""
 
     Regex.Matches(pageContent, pattern, RegexOptions.Singleline)
     |> Seq.cast<Match>
     |> Seq.toList
-    |> extractSection filePath None [ ]
+    |> List.choose (fun m ->
+        if m.Success then
+            {
+                Title = m.Groups.["h2_text"].Value
+                Link = m.Groups.["h2_link"].Value
+            }
+            |> Some
+        else
+            None)

--- a/src/Nacara.Layout.Standard/scss/nacara.scss
+++ b/src/Nacara.Layout.Standard/scss/nacara.scss
@@ -176,10 +176,15 @@ h2, h3, h4, h5, h6  {
             margin-bottom: 10rem;
         }
 
-        // Adds icon "external-link" to the right of the a tag.
-        a[target="_blank"]::after {
-            content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
-            margin: 0 3px 0 5px;
+        .menu-external-link {
+            position: relative;
+
+            &::after {
+                content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+                position: absolute;
+                top: calc(50% - 5px);
+                padding-left: 0.325rem;
+            }
         }
     }
 }

--- a/src/Nacara.Layout.Standard/scss/nacara.scss
+++ b/src/Nacara.Layout.Standard/scss/nacara.scss
@@ -167,6 +167,20 @@ h2, h3, h4, h5, h6  {
         margin-top: $navbar-height;
         padding-right: 1rem;
         padding-left: 1rem;
+
+        @include desktop {
+            margin-bottom: $navbar-height;
+        }
+
+        @include touch {
+            margin-bottom: 10rem;
+        }
+
+        // Adds icon "external-link" to the right of the a tag.
+        a[target="_blank"]::after {
+            content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+            margin: 0 3px 0 5px;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #76. Limits the table of content to h2. Minor visual improvements.

I've handled cases when there is no section, but a single page, or a single link. To all links in the menu that use target="_blank" I've added an icon so that the user knows what to expect when clicked.

See screenshots bellow:

![Web capture_28-8-2021_15611_localhost](https://user-images.githubusercontent.com/1839930/131220684-bd41cece-bad0-4685-bb35-99250fa1a51e.jpeg)
![Web capture_28-8-2021_154321_localhost](https://user-images.githubusercontent.com/1839930/131220687-55669635-b2d7-41c5-9bee-24e6cb3a005b.jpeg)
![Web capture_28-8-2021_153454_localhost](https://user-images.githubusercontent.com/1839930/131220688-dfdfc382-dffd-43d8-bac0-2afeb7e99197.jpeg)
![Web capture_28-8-2021_153126_localhost](https://user-images.githubusercontent.com/1839930/131220689-03c77974-75dc-44f2-8215-a1d85088f9b4.jpeg)
![Web capture_28-8-2021_15625_localhost](https://user-images.githubusercontent.com/1839930/131220690-db040558-9471-450f-8b6b-974a79139c50.jpeg)
