### PR TITLE
Fix anchor visibility

### DIFF
--- a/src/Nacara.Layout.Standard/Source/Page.Standard.fs
+++ b/src/Nacara.Layout.Standard/Source/Page.Standard.fs
@@ -281,12 +281,13 @@ let rehypePlugins : RehypePlugin array =
                         {|
                             ``type`` = "element"
                             tagName = "span"
-                            properties = {| className = ["anchor"] |}
-                            children = []
-                        |} |> box
-                        {|
-                            ``type`` = "text"
-                            value = "#"
+                            properties = {| className = "anchor" |}
+                            children = [|
+                                {|
+                                    ``type`` = "text"
+                                    value = "#"
+                                |} |> box
+                            |]
                         |} |> box
                     |]
                 |}

--- a/src/Nacara.Layout.Standard/scss/components/anchors.scss
+++ b/src/Nacara.Layout.Standard/scss/components/anchors.scss
@@ -1,15 +1,15 @@
 @charset "utf-8";
 
 // Anchor behavior
-h2, h3, h4, h5, h6  {
-    a {
+h1, h2, h3, h4, h5, h6  {
+    a span.anchor {
         visibility: hidden;
         margin-left: 0.5rem;
     }
 
     &:hover {
 
-        a {
+        a span.anchor {
             visibility: visible;
         }
     }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #149 

Corrects permanent anchor visibility for `<h1>` tags. 

Also moves the "#" content inside the `<span class="anchor"></span>`, fixes `className="anchor"` definition in `Page.Standard.fs`, and updates `anchors.scss` so that the visible-on-hover behavior applies specifically to "anchor"-class spans inside `<a>` tags. 

These changes will prevent odd `h1 > a`, `h2 > a`, etc. behavior if a user attempts to include a link in a heading. (As originally written, all links in headings would only be visible on hover, even ones that were not anchors but instead linked to another page or an external resource.)