### PR TITLE
Fix: The menu should be scrollable

### DIFF
--- a/src/Nacara.Layout.Standard/CHANGELOG.md
+++ b/src/Nacara.Layout.Standard/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.6.0 - 2022-02-10
+
+### Fixed
+
+* Fix #157: Make the menu scrollable if it goes out of screen (by @64J0)
+
 ## 1.5.0 - 2021-12-07
 
 ### Fixed

--- a/src/Nacara.Layout.Standard/scss/components/menu.scss
+++ b/src/Nacara.Layout.Standard/scss/components/menu.scss
@@ -11,6 +11,7 @@ $table-of-content-item-padding-left: 0.75rem !default;
     // margin: 3.25rem 0 0;
     overflow-y: auto;
     overscroll-behavior: contain;
+    max-height: calc(100vh - #{$computed-navbar-height});
 
     @include touch {
         height: calc(100vh - #{$computed-navbar-height});


### PR DESCRIPTION
Hey guys, I did some tests locally in Thoth.Json docs page ([reference link](https://thoth-org.github.io/Thoth.Json/documentation/auto/json-representation.html)) and apparently to achieve this property for the menu we just need to set `max-height: calc(100vh - margin)` attribute.

Please watch the video with my experiments:

https://user-images.githubusercontent.com/50725287/150610522-7349ac56-ed97-4dd3-9898-2327eb63fbf1.mp4